### PR TITLE
修复macOS系统`__dirname`错误，添加macOS打包脚本

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,6 @@ Home/
 无名杀-win32-x64/
 无名杀-win32-ia32/
 无名杀-linux-x64/
+无名杀-darwin-arm64/
+无名杀-darwin-x64/
 package-lock.json

--- a/extension/拖拽读取/extension.js
+++ b/extension/拖拽读取/extension.js
@@ -590,7 +590,7 @@ game.import("extension", function () {
 		},
 		help: {},
 		package: {
-			intro: `Windows/Linux电脑版专属扩展，把zip（离线包，扩展或素材压缩包）拖入到游戏内即可导入，现在可以导入有密码的压缩包了`,
+			intro: `Windows/Linux/macOS电脑版专属扩展，把zip（离线包，扩展或素材压缩包）拖入到游戏内即可导入，现在可以导入有密码的压缩包了`,
 			author: "诗笺",
 			diskURL: "",
 			forumURL: "",

--- a/extension/拖拽读取/info.json
+++ b/extension/拖拽读取/info.json
@@ -1,6 +1,6 @@
 {
 	"name": "拖拽读取",
-	"intro": "Windows/Linux电脑版专属扩展，把zip（离线包，扩展或素材压缩包）拖入到游戏内即可导入，现在可以导入有密码的压缩包了",
+	"intro": "Windows/Linux/macOS电脑版专属扩展，把zip（离线包，扩展或素材压缩包）拖入到游戏内即可导入，现在可以导入有密码的压缩包了",
 	"author": "诗笺",
 	"diskURL": "",
 	"forumURL": "",

--- a/extension/拖拽读取/worker.js
+++ b/extension/拖拽读取/worker.js
@@ -2,7 +2,17 @@ importScripts('./minizip-asm.min.js');
 
 if (globalThis.__dirname.includes('electron.asar')) {
     const path = require('path');
-    globalThis.__dirname = path.join(path.resolve(), 'resources/app/extension/拖拽读取');
+	if (globalThis.process.platform === "darwin") {
+		globalThis.__dirname = path.join(
+			globalThis.process.resourcesPath,
+			'app/extension/拖拽读取'
+		);
+	} else {
+		globalThis.__dirname = path.join(
+			path.resolve(),
+			'resources/app/extension/拖拽读取'
+		);
+	}
     const oldData = Object.entries(globalThis.require);
     // @ts-ignore
     globalThis.require = function (moduleId) {

--- a/game/game.js
+++ b/game/game.js
@@ -103,7 +103,11 @@
 		// 在http环境下修改__dirname和require的逻辑
 		if (window.__dirname.endsWith("electron.asar\\renderer") || window.__dirname.endsWith("electron.asar/renderer")) {
 			const path = require("path");
-			window.__dirname = path.join(path.resolve(), "resources/app");
+			if (window.process.platform === "darwin") {
+				window.__dirname = path.join(window.process.resourcesPath, "app");
+			} else {
+				window.__dirname = path.join(path.resolve(), "resources/app");
+			}
 			const oldData = Object.entries(window.require);
 			// @ts-ignore
 			window.require = function (moduleId) {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "start": "electron .",
     "packageWin64": "electron-packager . 无名杀 --platform=win32 --arch=x64 --out=./ --app-version=1.9.0 --icon=noname.ico --overwrite --ignore=./node_modules --ignore=.git --electron-version 33.2.0",
     "packageWin32": "electron-packager . 无名杀 --platform=win32 --arch=ia32 --out=./ --app-version=1.9.0 --icon=noname.ico --overwrite --ignore=./node_modules --ignore=.git --electron-version 33.2.0",
-    "packageLinux": "electron-packager . 无名杀 --platform=linux --arch=x64 --out=./ --app-version=1.9.0 --icon=noname.ico --overwrite --ignore=./node_modules --ignore=.git --electron-version 33.2.0"
+    "packageLinux": "electron-packager . 无名杀 --platform=linux --arch=x64 --out=./ --app-version=1.9.0 --icon=noname.ico --overwrite --ignore=./node_modules --ignore=.git --electron-version 33.2.0",
+    "packageDarwin": "electron-packager . 无名杀 --platform=darwin --arch=arm64 --out=./ --app-version=1.9.0 --icon=noname.icns --overwrite --ignore=./node_modules --ignore=.git --electron-version 33.2.0",
+    "packageDarwinIntel": "electron-packager . 无名杀 --platform=darwin --arch=x64 --out=./ --app-version=1.9.0 --icon=noname.icns --overwrite --ignore=./node_modules --ignore=.git --electron-version 33.2.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
### PR受影响的平台
macOS，Electron客户端

### 诱因和背景
修复macOS下__dirname不能正确获取，导致扩展读取导出异常的问题，补充macOS打包脚本。


### PR描述
在`game/game.js`和`extension/拖拽读取/worker.js`中，在macOS平台下，修改`__dirname`的获取逻辑，利用`process.resourcesPath`取得正确路径。


### PR测试
1. 运行`npm run packageDarwin`，可以生成应用包；

2. 运行生成的应用包，可以正常增删导出扩展；

3. 尝试利用完整包进行拖拽安装，可以正常进行安装；

4. 创建一个扩展，导出后导入未见异常。


### 扩展适配
无需适配，未使用`__dirname`的扩展需检查路径是否正确。



### 检查清单
- [x] 我已经进行了充足的测试，且现有的测试都已通过
- [x] 如果此次PR涉及到新功能的添加，我已在`PR描述`中写入详细文档
- [x] 如果此次PR需要扩展跟进，我已在`扩展适配`中写入详细文档
- [x] 如果这个PR解决了一个issue，我在`诱因和背景`中明确链接到该issue
- [x] 我保证该PR中没有随意修改换行符等内容，没有制造出大量的Diff
- [x] 我保证该PR遵循项目中`.editorconfig`、`.eslintrc.json`和`.prettierrc`所规定的代码样式，并且已经通过`prettier`格式化过代码
